### PR TITLE
Change include order

### DIFF
--- a/crypto_helper_openssl.c
+++ b/crypto_helper_openssl.c
@@ -7,13 +7,13 @@
  * releases.
  */
 
+#include "crypto_helper.h"
+
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
-
-#include "crypto_helper.h"
 
 static const EVP_MD* evp_md = NULL;
 


### PR DESCRIPTION
Changed the order of `include` so that it can be compiled with OpenSSL 1.1.1a.